### PR TITLE
avoid using rest parameters

### DIFF
--- a/lib/Ribosome.js
+++ b/lib/Ribosome.js
@@ -13,9 +13,9 @@ const stream = require('stream');
 
 const PROTEIN_HEADER_SIZE = 8;
 
-function debuglog(...argz) {
+function debuglog() {
   if (false) { // eslint-disable-line no-constant-condition
-    console.log(...argz);
+    console.log.apply(this, arguments);
   }
 }
 


### PR DESCRIPTION
This makes it compatible with older versions of node (e.g. node 4.2.6 that comes
with Ubuntu 16.04).